### PR TITLE
jupyter: pin stage versions to 3.10

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ARG WHEEL_DIST="/tmp/wheels"
 
-FROM python:3.9-slim-bullseye as builder
+FROM python:3.10-slim-bullseye as builder
 ARG WHEEL_DIST
 
 RUN apt-get update && \
@@ -25,7 +25,7 @@ COPY . /src
 WORKDIR /src
 RUN python3 -m pip wheel -w "${WHEEL_DIST}" .
 
-FROM jupyter/scipy-notebook
+FROM jupyter/scipy-notebook:ubuntu-22.04
 
 LABEL maintainer="Stamus Networks oss@stamus-networks.com"
 


### PR DESCRIPTION
Jupyter container base seems to have been updated. That broke multi-stage build, as wheels built on 3.9 could not be installed on ubuntu 22.04 with 3.10.

This patch upgrades builder and locks jupyter to avoid this issue.