### PR TITLE
docker: explicit string mapping for compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     image: stamus/jupyter:${TAG:-latest}
     restart: ${RESTART_MODE:-no}
     environment:
-      SCIRIUS_ENVFILE_IN_HOME: yes
+      SCIRIUS_ENVFILE_IN_HOME: "yes"
     volumes:
       - ${PWD}/.env:/home/jovyan/.env:ro
       - ${PWD}:/home/jovyan/work:rw


### PR DESCRIPTION
docker-compose crashes in some versions, since unquoted *yes* becomes a boolean.