### PR TITLE
python: dependency updates

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -101,7 +101,7 @@ RUN make -j ${BUILD_WORKERS}
 RUN make install
 RUN make install-conf
 
-FROM jupyter/scipy-notebook:ubuntu-22.04
+FROM jupyter/scipy-notebook:lab-3.6.3
 
 LABEL maintainer="Stamus Networks oss@stamus-networks.com"
 

--- a/python/surianalytics/widgets/explorer.py
+++ b/python/surianalytics/widgets/explorer.py
@@ -22,9 +22,6 @@ import pickle
 import os
 import re
 
-from msticpy.vis.timeline import display_timeline
-from msticpy.vis.timeline_duration import display_timeline_duration
-
 
 CORE_COLUMNS = ["timestamp",
                 "flow_id",
@@ -107,7 +104,6 @@ class Explorer(object):
         self._register_eve_aggregator()
         self._register_uniq()
         self._register_graph()
-        self._register_timeline()
         self._register_tabs(debug)
 
     def _register_shared_widgets(self) -> None:
@@ -272,42 +268,12 @@ class Explorer(object):
                                         self._output_graph,
                                         self._output_graph_feedback])
 
-    def _register_timeline(self) -> None:
-        graph_w = [r.split("x")[0] for r in GRAPH_RESOLUTIONS]
-        graph_h = [r.split("x")[1] for r in GRAPH_RESOLUTIONS]
-
-        self._dropdown_graph_w = widgets.Dropdown(
-            description="Width",
-            options=graph_w,
-            value=graph_w[1]
-        )
-        self._dropdown_graph_h = widgets.Dropdown(
-            description="Height",
-            options=graph_h,
-            value=graph_h[1]
-        )
-
-        self._button_draw_timeline = widgets.Button(description="Draw timeline")
-        self._button_draw_timeline.on_click(self._display_timeline)
-
-        self._box_timeline = widgets.VBox([self._dropdown_graph_w,
-                                           self._dropdown_graph_h,
-                                           self._select_agg_col,
-                                           self._button_draw_timeline])
-
-        self._box_timeline = widgets.HBox([self._box_search_area,
-                                           self._box_timeline])
-
-        self._box_timeline = widgets.VBox([self._box_timeline,
-                                           self._output_timeline])
-
     def _register_tabs(self, debug: bool) -> None:
         boxes = [
             (self._box_eve_explorer, "Expore"),
             (self._box_eve_agg, "Aggregate"),
             (self._box_uniq, "Uniq"),
             (self._box_graph, "Graph"),
-            (self._box_timeline, "Timeline")
         ]
         if debug:
             boxes.append((self._output_debug, "Debug"))
@@ -481,25 +447,6 @@ class Explorer(object):
 
             print("Number of clusters: {}".format(len(component_sizes)))
             display(res)
-
-    def _display_timeline(self, args) -> None:
-        self._output_timeline.clear_output()
-        with self._output_timeline:
-            display_timeline(
-                self.data_filtered.fillna(""),
-                group_by=self._select_agg_col.value,
-                time_column="timestamp",
-                legend="right",
-                width=int(self._dropdown_graph_w.value),
-                height=int(self._dropdown_graph_h.value)
-            )
-            display_timeline_duration(
-                self.data_filtered.fillna(""),
-                group_by=self._select_agg_col.value,
-                time_column="timestamp",
-                width=int(self._dropdown_graph_w.value),
-                height=int(self._dropdown_graph_h.value)
-            )
 
     def _display_aggregate_event_types(self):
         self._output_debug.clear_output()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+jupyter
+jupyterlab==3.6.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,17 +24,14 @@ package_dir=
     =python
 packages=find:
 install_requires=
-    jupyter == 1.0.0
-    jupyterlab == 3.5.0
-    numpy <=1.23.3
-    pandas <=1.5.1
-    networkx <=2.8.7
-    requests <=2.28.1
-    python-dotenv <=0.21.0
-    ipywidgets == 8.0.2
-    holoviews == 1.15.2
-    hvplot == 0.8.2
-    msticpy == 2.1.4
+    numpy == 1.24.2
+    pandas == 2.0.2
+    networkx == 3.1
+    requests == 2.31.0
+    python-dotenv == 1.0.0
+    ipywidgets == 8.0.6
+    holoviews == 1.16.0
+    hvplot == 0.8.3
 
 [options.packages.find]
 where=python


### PR DESCRIPTION
* remove msticpy for now since its deps collide with latest goodies;
* remove jupyter and lab from lib deps since that collides with docker image static version;
* pin jupyterlab to 3.6.3 since 4.0.0 breaks ipywidgets;